### PR TITLE
async detection fix.

### DIFF
--- a/web/px-async.js
+++ b/web/px-async.js
@@ -15,7 +15,7 @@ var AdblockPlus = new function () {
     }
     
     function checkImages() {
-      if (++checksRemain) return;
+      if (--checksRemain) return;
       detected = !error1 && error2
     }
     


### PR DESCRIPTION
should be --checksremain to countdown until both pixels are checked.
Still takes about 0.9 secs to load.